### PR TITLE
Use TCP_CORK on Linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ encoding_rs = { version = "0.8", optional = true }
 flate2 = { version = "1.0", optional = true }
 http = "0.2"
 httparse = "1.3"
+libc = "0.2"
 native-tls = { version = "0.2", optional = true }
 rustls = { version = "0.19", optional = true }
 serde = { version = "1.0", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,6 +98,12 @@ impl From<io::ErrorKind> for Error {
     }
 }
 
+impl<W> From<io::IntoInnerError<W>> for Error {
+    fn from(err: io::IntoInnerError<W>) -> Self {
+        Self::Io(err.into())
+    }
+}
+
 impl From<http::Error> for Error {
     fn from(err: http::Error) -> Self {
         Self::Http(err)


### PR DESCRIPTION
To avoid delay sending of request due to Nagle's algorithm while also avoiding to send partial segments due to fixed buffer size.