### PR TITLE
Use TCP_NODELAY to disable Nagle's algorithm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,9 @@ use stream::Stream;
 
 pub trait RequestBuilderExt {
     fn empty(self) -> Result<Request<EmptyBody>, HttpError>;
+    #[allow(clippy::wrong_self_convention)]
     fn from_mem<B: AsRef<[u8]>>(self, body: B) -> Result<Request<MemBody<B>>, HttpError>;
+    #[allow(clippy::wrong_self_convention)]
     fn from_io<B: Seek + Read>(self, body: B) -> Result<Request<IoBody<B>>, HttpError>;
     #[cfg(feature = "json")]
     fn json<B: Serialize>(self, body: B) -> Result<Request<JsonBody<B>>, HttpError>;
@@ -342,6 +344,8 @@ fn write_request<B: BodyWriter>(
     } else {
         body.write(&mut writer)?;
     }
+
+    writer.get_ref().set_nodelay(true)?;
 
     writer.flush()?;
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -88,6 +88,20 @@ impl Stream {
             }
         }
     }
+
+    pub fn set_nodelay(&self, val: bool) -> IoResult<()> {
+        match self {
+            Self::Tcp(stream) | Self::TcpWithTimeout(stream, _) => stream.set_nodelay(val),
+            #[cfg(feature = "native-tls")]
+            Self::NativeTls(stream) | Self::NativeTlsWithTimeout(stream, _) => {
+                stream.get_ref().set_nodelay(val)
+            }
+            #[cfg(feature = "tls")]
+            Self::Rustls(stream) | Self::RustlsWithTimeout(stream, _) => {
+                stream.sock.set_nodelay(val)
+            }
+        }
+    }
 }
 
 #[cfg(feature = "native-tls")]


### PR DESCRIPTION
Before the last write system call to improve latency, emulating the effect of TCP_CORK as long as the request length is not a multiple of the buffer size.